### PR TITLE
Fix igraph conversions

### DIFF
--- a/rwrap/converter.py
+++ b/rwrap/converter.py
@@ -29,7 +29,13 @@ def importr_cached(pkg_name, reload=False):
     """`importr` with caching."""
     if reload and pkg_name in R_MODULE_DICT:
         del R_MODULE_DICT[pkg_name]
-    return R_MODULE_DICT.setdefault(pkg_name, importr(pkg_name))
+
+    # prevent crash: "rpy2.robjects.packages.LibraryError: The symbol .env in the package "igraph" is conflicting with a Python object attribute"
+    robject_translations = {".env": "__env"}
+
+    return R_MODULE_DICT.setdefault(
+        pkg_name, importr(pkg_name, robject_translations=robject_translations)
+    )
 
 
 # setup converter

--- a/rwrap/wrapper.py
+++ b/rwrap/wrapper.py
@@ -16,7 +16,13 @@ class RLibraryWrapper:
 
     def __init__(self, lib_name: str) -> None:
         """Import R package."""
-        self.__lib = importr(lib_name.replace("_", "."))
+
+        # prevent crash: "rpy2.robjects.packages.LibraryError: The symbol .env in the package "igraph" is conflicting with a Python object attribute"
+        robject_translations = {".env": "__env"}
+
+        self.__lib = importr(
+            lib_name.replace("_", "."), robject_translations=robject_translations
+        )
 
     def __getattr__(self, name: str) -> Callable:
         """Access method of R package."""

--- a/rwrap/wrapper.py
+++ b/rwrap/wrapper.py
@@ -8,7 +8,7 @@ import rpy2.robjects as ro
 from rpy2.robjects.packages import importr
 from rpy2.robjects.conversion import localconverter
 
-from .converter import converter
+from .converter import converter, importr_cached
 
 
 class RLibraryWrapper:
@@ -16,13 +16,7 @@ class RLibraryWrapper:
 
     def __init__(self, lib_name: str) -> None:
         """Import R package."""
-
-        # prevent crash: "rpy2.robjects.packages.LibraryError: The symbol .env in the package "igraph" is conflicting with a Python object attribute"
-        robject_translations = {".env": "__env"}
-
-        self.__lib = importr(
-            lib_name.replace("_", "."), robject_translations=robject_translations
-        )
+        self.__lib = importr_cached(lib_name.replace("_", "."))
 
     def __getattr__(self, name: str) -> Callable:
         """Access method of R package."""

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -71,34 +71,34 @@ from rwrap.converter import converter
                 ]
             ),
         ),
-        # # networks
-        # (
-        #     "igraph::graph_from_data_frame(data.frame(from = c('A', 'B'), to = c('B', 'C')), directed = FALSE)",
-        #     igraph.Graph(
-        #         n=3,
-        #         edges=[(0, 1), (1, 2)],
-        #         directed=False,
-        #         vertex_attrs={"name": ["A", "B", "C"], "id": ["n0", "n1", "n2"]},
-        #     ),
-        # ),
-        # (
-        #     "igraph::make_(igraph::ring(4), igraph::with_vertex_(name = letters[1:4], color = 'red'), igraph::with_edge_(weight = 1:4, color = 'green'))",
-        #     igraph.Graph(
-        #         n=4,
-        #         edges=[(0, 1), (1, 2), (2, 3), (3, 0)],
-        #         directed=False,
-        #         graph_attrs={"name": "Ring graph", "mutual": False, "circular": True},
-        #         vertex_attrs={
-        #             "name": ["a", "b", "c", "d"],
-        #             "color": ["red", "red", "red", "red"],
-        #             "id": ["n0", "n1", "n2", "n3"],
-        #         },
-        #         edge_attrs={
-        #             "weight": [1, 2, 3, 4],
-        #             "color": ["green", "green", "green", "green"],
-        #         },
-        #     ),
-        # ),
+        # networks
+        (
+            "igraph::graph_from_data_frame(data.frame(from = c('A', 'B'), to = c('B', 'C')), directed = FALSE)",
+            igraph.Graph(
+                n=3,
+                edges=[(0, 1), (1, 2)],
+                directed=False,
+                vertex_attrs={"name": ["A", "B", "C"], "id": ["n0", "n1", "n2"]},
+            ),
+        ),
+        (
+            "igraph::make_(igraph::ring(4), igraph::with_vertex_(name = letters[1:4], color = 'red'), igraph::with_edge_(weight = 1:4, color = 'green'))",
+            igraph.Graph(
+                n=4,
+                edges=[(0, 1), (1, 2), (2, 3), (3, 0)],
+                directed=False,
+                graph_attrs={"name": "Ring graph", "mutual": False, "circular": True},
+                vertex_attrs={
+                    "name": ["a", "b", "c", "d"],
+                    "color": ["red", "red", "red", "red"],
+                    "id": ["n0", "n1", "n2", "n3"],
+                },
+                edge_attrs={
+                    "weight": [1, 2, 3, 4],
+                    "color": ["green", "green", "green", "green"],
+                },
+            ),
+        ),
     ],
 )
 def test_equality(tmp_path, r_expr, py_data):


### PR DESCRIPTION
Crash:
```python
rpy2.robjects.packages.LibraryError: The symbol .env in the package "igraph" is conflicting with a Python object attribute
```